### PR TITLE
bump rustler to 0.21

### DIFF
--- a/serde_rustler/Cargo.toml
+++ b/serde_rustler/Cargo.toml
@@ -17,6 +17,5 @@ crate-type = ["rlib"]
 [dependencies]
 lazy_static = "1.0"
 quick-error = "1.2"
-rustler = "0.20.0"
-rustler_codegen = "0.20.0"
+rustler = "0.21"
 serde = "1.0"

--- a/serde_rustler/src/lib.rs
+++ b/serde_rustler/src/lib.rs
@@ -6,7 +6,6 @@
 extern crate lazy_static;
 #[macro_use]
 extern crate rustler;
-extern crate rustler_codegen;
 
 pub mod atoms;
 mod de;


### PR DESCRIPTION
Hi @sunny-g! Thanks for creating this crate!

This PR bumps the rustler version to support `0.21`.

I'm also reaching out to see if you'd be interested in moving this crate into the `rustler` workspace so that we could keep it in sync and help out with the maintenance?

What do you think?