### PR TITLE
Set macOS rustflags on both x86 and ARM

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -1,4 +1,4 @@
-[target.x86_64-apple-darwin]
+[target.'cfg(target_os = "macos")']
 rustflags = [
   "-C", "link-arg=-undefined",
   "-C", "link-arg=dynamic_lookup",


### PR DESCRIPTION
Now that "apple silicon" is a thing, we need to conditionally set the rust flags for any hardware running macOS.