### PR TITLE
chore(deps): version up to rustler to 0.22

### DIFF
--- a/serde_rustler/Cargo.toml
+++ b/serde_rustler/Cargo.toml
@@ -17,6 +17,5 @@ crate-type = ["rlib"]
 [dependencies]
 lazy_static = "1.4.0"
 quick-error = "1.2"
-rustler = "0.21.0"
-rustler_codegen = "0.21.0"
+rustler = "^0.22"
 serde = "1.0"

--- a/serde_rustler/src/atoms.rs
+++ b/serde_rustler/src/atoms.rs
@@ -8,24 +8,24 @@ lazy_static! {
     pub static ref ERROR: String = String::from("Err");
 }
 
-rustler_atoms! {
+rustler::atoms! {
     /// The atom `nil`.
-    atom nil;
+     nil,
 
     /// The atom `:ok`.
-    atom ok;
+     ok,
 
     /// The atom `:error`.
-    atom error;
+     error,
 
     /// The atom/Boolean `true`.
-    atom true_ = "true";
+     true_ = "true",
 
     /// The atom/Boolean `false`.
-    atom false_ = "false";
+     false_ = "false",
 
     /// The atom `:__struct__`.
-    atom __struct__;
+     __struct__,
 }
 
 /**

--- a/serde_rustler/src/lib.rs
+++ b/serde_rustler/src/lib.rs
@@ -4,9 +4,7 @@
 
 #[macro_use]
 extern crate lazy_static;
-#[macro_use]
 extern crate rustler;
-extern crate rustler_codegen;
 
 pub mod atoms;
 mod de;

--- a/serde_rustler_tests/mix.exs
+++ b/serde_rustler_tests/mix.exs
@@ -29,7 +29,6 @@ defmodule SerdeRustlerTests.Mixfile do
       elixir:             "~> 1.8",
       build_embedded:     in_production,
       start_permanent:    in_production,
-      compilers:          [:rustler] ++ Mix.compilers(),
       rustler_crates:     rustler_crates(),
     ]
   end
@@ -45,7 +44,7 @@ defmodule SerdeRustlerTests.Mixfile do
   end
 
   defp deps() do
-    [ {:rustler,        "~> 0.20.0"},
+    [ {:rustler,        "~> 0.22"},
     ]
   end
 

--- a/serde_rustler_tests/native/serde_rustler_tests/Cargo.toml
+++ b/serde_rustler_tests/native/serde_rustler_tests/Cargo.toml
@@ -12,8 +12,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 lazy_static = "1.0"
-rustler = "0.21.0"
-rustler_codegen = "0.21.0"
+rustler = "^0.22"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = "1.0"


### PR DESCRIPTION
This includes some deprecated warnings.